### PR TITLE
Feature/sc 82258/updating down migration text take 2

### DIFF
--- a/lib/commands/create-migration.js
+++ b/lib/commands/create-migration.js
@@ -119,6 +119,7 @@ function shouldCreateCoffeeFile (internals, config) {
   return internals.argv['coffee-file'] || config['coffee-file'];
 }
 
+// =+=+ patriq => this function is what is actually responsible for creating sql files!
 function createSqlFiles (internals, config, callback) {
   var migrationsDir = internals.argv['migrations-dir'];
 
@@ -142,6 +143,7 @@ function createSqlFiles (internals, config, callback) {
       }
     }
 
+    // =+=+ the first callback creates the up .sql
     var templateTypeDefaultSQL = Migration.TemplateType.DEFAULT_SQL;
     var migrationUpSQL = new Migration(
       internals.argv.title + '-up.sql',
@@ -154,12 +156,12 @@ function createSqlFiles (internals, config, callback) {
         log.info(
           util.format('Created migration up sql file at %s', migration.path)
         );
-
+        // =+=+ and the second creates the down .sql
         var migrationDownSQL = new Migration(
           internals.argv.title + '-down.sql',
           sqlDir,
           internals.runTimestamp,
-          templateTypeDefaultSQL
+          '/* we dont really support down migrations. running them could have catastrophic effects!! */'
         );
         index.createMigration(migrationDownSQL, function (err, migration) {
           if (_assert(err, callback)) {

--- a/lib/commands/create-migration.js
+++ b/lib/commands/create-migration.js
@@ -144,7 +144,7 @@ function createSqlFiles (internals, config, callback) {
     }
 
     // =+=+ the first callback creates the up .sql
-    var templateTypeDefaultSQL = Migration.TemplateType.DEFAULT_SQL;
+    var templateTypeDefaultSQL = Migration.TemplateType.SQL_UP;
     var templateTypeDownSQL = Migration.TemplateType.SQL_DOWN;
 
     var migrationUpSQL = new Migration(

--- a/lib/commands/create-migration.js
+++ b/lib/commands/create-migration.js
@@ -115,8 +115,8 @@ function shouldIgnoreOnInitFiles (internals, config) {
   return internals.argv['ignore-on-init'] || config['ignore-on-init'];
 }
 
-function shouldCreateCoffeeFile (/*internals, config*/) {
-  return false;
+function shouldCreateCoffeeFile (internals, config) {
+  return internals.argv['coffee-file'] || config['coffee-file'];
 }
 
 // =+=+ patriq => this function is what is actually responsible for creating sql files!

--- a/lib/commands/create-migration.js
+++ b/lib/commands/create-migration.js
@@ -145,6 +145,8 @@ function createSqlFiles (internals, config, callback) {
 
     // =+=+ the first callback creates the up .sql
     var templateTypeDefaultSQL = Migration.TemplateType.DEFAULT_SQL;
+    var templateTypeDownSQL = Migration.TemplateType.SQL_DOWN;
+
     var migrationUpSQL = new Migration(
       internals.argv.title + '-up.sql',
       sqlDir,
@@ -161,7 +163,7 @@ function createSqlFiles (internals, config, callback) {
           internals.argv.title + '-down.sql',
           sqlDir,
           internals.runTimestamp,
-          '/* we dont really support down migrations. running them could have catastrophic effects!! */'
+          templateTypeDownSQL
         );
         index.createMigration(migrationDownSQL, function (err, migration) {
           if (_assert(err, callback)) {

--- a/lib/commands/create-migration.js
+++ b/lib/commands/create-migration.js
@@ -115,8 +115,8 @@ function shouldIgnoreOnInitFiles (internals, config) {
   return internals.argv['ignore-on-init'] || config['ignore-on-init'];
 }
 
-function shouldCreateCoffeeFile (internals, config) {
-  return internals.argv['coffee-file'] || config['coffee-file'];
+function shouldCreateCoffeeFile (/*internals, config*/) {
+  return false;
 }
 
 // =+=+ patriq => this function is what is actually responsible for creating sql files!

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -118,6 +118,10 @@ Migration.prototype.defaultSqlTemplate = function () {
   return '/* Replace with your SQL commands */';
 };
 
+Migration.prototype.downSqlTemplate = function() {
+  return '/* when i step, you step */';
+}
+
 Migration.prototype.sqlFileLoaderTemplate = function () {
   return [
     "'use strict';",
@@ -300,7 +304,8 @@ Migration.TemplateType = {
   SQL_FILE_LOADER: 2,
   DEFAULT_COFFEE: 3,
   COFFEE_SQL_FILE_LOADER: 4,
-  SQL_FILE_LOADER_IGNORE_ON_INIT: 5
+  SQL_FILE_LOADER_IGNORE_ON_INIT: 5,
+  SQL_DOWN: 6,
 };
 
 // +=+= patriq => this function determines which "template" to use
@@ -317,6 +322,8 @@ Migration.prototype.getTemplate = function () {
       return this.coffeeSqlFileLoaderTemplate();
     case Migration.TemplateType.SQL_FILE_LOADER_IGNORE_ON_INIT:
       return this.sqlFileLoaderIgnoreOnInitTemplate();
+    case Migration.TemplateType.SQL_DOWN:
+      return this.downSqlTemplate()
     case Migration.TemplateType.DEFAULT_JS:
     /* falls through */
     default:

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -113,8 +113,10 @@ Migration.prototype.defaultJsTemplate = function () {
   ].join('\n');
 };
 
-// +=+= patriq => this is our default sql comments!
-Migration.prototype.defaultSqlTemplate = function () {
+// +=+= patriq => this is our default sql comments! ///////////////////////////////////////////////
+//                the name "sqlFileLoaderTemplate" is a little confusing... it is the template for
+//                our auto-generated js files, which actually run the SQL we write!
+Migration.prototype.sqlUpTemplate = function () {
   return '/* when i step, you step */';
 };
 
@@ -184,6 +186,7 @@ Migration.prototype.sqlFileLoaderTemplate = function () {
     ''
   ].join('\n');
 };
+///////////////////////////////////////////////////////////////////////////////////////////////////
 
 Migration.prototype.sqlFileLoaderIgnoreOnInitTemplate = function () {
   return [
@@ -300,7 +303,7 @@ Migration.prototype.coffeeSqlFileLoaderTemplate = function () {
 
 Migration.TemplateType = {
   DEFAULT_JS: 0,
-  DEFAULT_SQL: 1,
+  SQL_UP: 1,
   SQL_FILE_LOADER: 2,
   DEFAULT_COFFEE: 3,
   COFFEE_SQL_FILE_LOADER: 4,
@@ -312,8 +315,10 @@ Migration.TemplateType = {
 //                (theyre just stings that get written to a new file with a specific extension)
 Migration.prototype.getTemplate = function () {
   switch (this.templateType) {
-    case Migration.TemplateType.DEFAULT_SQL:
-      return this.defaultSqlTemplate();
+    case Migration.TemplateType.SQL_UP:
+      return this.sqlUpTemplate();
+    case Migration.TemplateType.SQL_DOWN:
+      return this.downSqlTemplate();
     case Migration.TemplateType.SQL_FILE_LOADER:
       return this.sqlFileLoaderTemplate();
     case Migration.TemplateType.DEFAULT_COFFEE:
@@ -322,8 +327,6 @@ Migration.prototype.getTemplate = function () {
       return this.coffeeSqlFileLoaderTemplate();
     case Migration.TemplateType.SQL_FILE_LOADER_IGNORE_ON_INIT:
       return this.sqlFileLoaderIgnoreOnInitTemplate();
-    case Migration.TemplateType.SQL_DOWN:
-      return this.downSqlTemplate();
     case Migration.TemplateType.DEFAULT_JS:
     /* falls through */
     default:

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -302,10 +302,9 @@ Migration.TemplateType = {
   DEFAULT_JS: 0,
   DEFAULT_SQL: 1,
   SQL_FILE_LOADER: 2,
-  DEFAULT_COFFEE: 3,
+  SQL_DOWN: 3,
   COFFEE_SQL_FILE_LOADER: 4,
   SQL_FILE_LOADER_IGNORE_ON_INIT: 5,
-  SQL_DOWN: 6,
 };
 
 // +=+= patriq => this function determines which "template" to use
@@ -316,14 +315,12 @@ Migration.prototype.getTemplate = function () {
       return this.defaultSqlTemplate();
     case Migration.TemplateType.SQL_FILE_LOADER:
       return this.sqlFileLoaderTemplate();
-    case Migration.TemplateType.DEFAULT_COFFEE:
-      return this.defaultCoffeeTemplate();
+    case Migration.TemplateType.SQL_DOWN:
+        return this.downSqlTemplate()
     case Migration.TemplateType.COFFEE_SQL_FILE_LOADER:
       return this.coffeeSqlFileLoaderTemplate();
     case Migration.TemplateType.SQL_FILE_LOADER_IGNORE_ON_INIT:
       return this.sqlFileLoaderIgnoreOnInitTemplate();
-    case Migration.TemplateType.SQL_DOWN:
-      return this.downSqlTemplate()
     case Migration.TemplateType.DEFAULT_JS:
     /* falls through */
     default:

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -113,6 +113,7 @@ Migration.prototype.defaultJsTemplate = function () {
   ].join('\n');
 };
 
+// +=+= patriq => this is our default sql comments!
 Migration.prototype.defaultSqlTemplate = function () {
   return '/* Replace with your SQL commands */';
 };
@@ -302,6 +303,8 @@ Migration.TemplateType = {
   SQL_FILE_LOADER_IGNORE_ON_INIT: 5
 };
 
+// +=+= patriq => this function determines which "template" to use
+//                (theyre just stings that get written to a new file with a specific extension)
 Migration.prototype.getTemplate = function () {
   switch (this.templateType) {
     case Migration.TemplateType.DEFAULT_SQL:

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -115,11 +115,11 @@ Migration.prototype.defaultJsTemplate = function () {
 
 // +=+= patriq => this is our default sql comments!
 Migration.prototype.defaultSqlTemplate = function () {
-  return '/* Replace with your SQL commands */';
+  return '/* when i step, you step */';
 };
 
 Migration.prototype.downSqlTemplate = function() {
-  return '/* when i step, you step */';
+  return '/* when i dont step, you dont step */';
 }
 
 Migration.prototype.sqlFileLoaderTemplate = function () {
@@ -302,9 +302,10 @@ Migration.TemplateType = {
   DEFAULT_JS: 0,
   DEFAULT_SQL: 1,
   SQL_FILE_LOADER: 2,
-  SQL_DOWN: 3,
+  DEFAULT_COFFEE: 3,
   COFFEE_SQL_FILE_LOADER: 4,
   SQL_FILE_LOADER_IGNORE_ON_INIT: 5,
+  SQL_DOWN: 6,
 };
 
 // +=+= patriq => this function determines which "template" to use
@@ -315,12 +316,14 @@ Migration.prototype.getTemplate = function () {
       return this.defaultSqlTemplate();
     case Migration.TemplateType.SQL_FILE_LOADER:
       return this.sqlFileLoaderTemplate();
-    case Migration.TemplateType.SQL_DOWN:
-        return this.downSqlTemplate()
+    case Migration.TemplateType.DEFAULT_COFFEE:
+      return this.defaultCoffeeTemplate();
     case Migration.TemplateType.COFFEE_SQL_FILE_LOADER:
       return this.coffeeSqlFileLoaderTemplate();
     case Migration.TemplateType.SQL_FILE_LOADER_IGNORE_ON_INIT:
       return this.sqlFileLoaderIgnoreOnInitTemplate();
+    case Migration.TemplateType.SQL_DOWN:
+      return this.downSqlTemplate();
     case Migration.TemplateType.DEFAULT_JS:
     /* falls through */
     default:

--- a/test/migration_test.js
+++ b/test/migration_test.js
@@ -204,7 +204,7 @@ function getTemplate () {
         fileName,
         dirName,
         date,
-        Migration.TemplateType.DEFAULT_SQL,
+        Migration.TemplateType.SQL_UP,
         internals
       );
 
@@ -213,7 +213,7 @@ function getTemplate () {
 
         function (done) {
           var actual = migration.getTemplate();
-          Code.expect(actual).to.equal(migration.defaultSqlTemplate());
+          Code.expect(actual).to.equal(migration.sqlUpTemplate());
           done();
         }
       );


### PR DESCRIPTION
## Context/Background
- We would like to customize the text autogenerated in our up/down sql files!
- UW is built on top of a forked version of node-db-migrate (i.e. this repo)
- Technically, UW is built on an old tag. NOT a branch. So, the base branch for this PR (`alloy-master-at-v0.10.1`) is a branch i made, after checking out that old tag

## Description of the Change
- Writing comments about the relevant functions for generating SQL code, and the SQL file loader (i.e our JS file)

## Steps To Test
https://user-images.githubusercontent.com/16801108/179156661-11c93012-e92b-43fa-accf-b65a58afe8ff.mov

## Possible Drawbacks
- Need to come up with a good name for that base branch, & make it protected so people cant accidentally modify/delete it
- Changes to this repo requires developers to npm i before running any migration. maybe we can automate this somehow?
- Maybe we can actually upgrade UW to a newer version of `node-db-migrate` before making these changes? From what I could tell at a glance, things were not widely different 